### PR TITLE
Feature proxy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ Programmed because some rapla calendars (especially the DHBW ones) don't have th
 ## Usage
 Download rapla2csv JAR, switch to download directory, open command line and use `java -jar rapla2csv.jar -h` so see all command line options:
 
-    usage: rapla2csv -f <date> -u <date> -l <link> [-o <CSV-file>] [-h] [-v]
-     -f,--from <date>         Begin of the export time period, e.g. 2015-12-31
-     -h,--help                Shows this help
-     -l,--link <link>         Rapla link IN QUOTES, e.g.
-                              "http://example.com/rapla?key=abc123"
-     -o,--output <CSV-file>   CSV file to save the rapla lessons into
-     -u,--until <date>        End of the export time period, e.g. 2016-12-31
-     -v,--version             Show version number
+    usage: rapla2csv -f <date> -u <date> -l <link> [-p <proxy string>] [-o <CSV-file>] [-h] [-v]
+     -f,--from <date>           Begin of the export time period, e.g. 2015-12-31
+     -h,--help                  Shows this help
+     -l,--link <link>           Rapla link IN QUOTES, e.g.
+                                "http://example.com/rapla?key=abc123"
+     -o,--output <CSV-file>     CSV file to save the rapla lessons into
+     -p,--proxy <proxy string>  Your proxy settings in format host:port, e.g.
+                                myHost:1234
+     -u,--until <date>          End of the export time period, e.g. 2016-12-31
+     -v,--version               Show version number

--- a/src/main/java/de/lippertmarkus/rapla2csv/RaplaReader.java
+++ b/src/main/java/de/lippertmarkus/rapla2csv/RaplaReader.java
@@ -3,16 +3,15 @@ package de.lippertmarkus.rapla2csv;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
+import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import javax.print.DocFlavor;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.DayOfWeek;
@@ -42,6 +41,11 @@ public class RaplaReader
      * Link to the rapla web calendar view with a key or a user and file
      */
     private URIBuilder raplaLink;
+
+    /**
+     * Proxy setting if provided
+     */
+    private Proxy proxy;
 
     /**
      * List of the extracted lessons
@@ -113,6 +117,10 @@ public class RaplaReader
         dateFrom = from;
         dateUntil = until;
         this.raplaLink = prepareRaplaUri(raplaLink);
+    }
+
+    public void setProxy(Proxy proxy) {
+        this.proxy = proxy;
     }
 
     /**
@@ -230,8 +238,14 @@ public class RaplaReader
     {
         setRaplaUrlDateParameters(weekMondayDate, raplaLink);
 
+        Connection raplaConnection = Jsoup.connect(raplaLink.toString());
+
+        // set proxy if provided
+        if(proxy != null)
+            raplaConnection.proxy(proxy);
+
         // get HTML document for current week
-        Document doc = Jsoup.connect(raplaLink.toString()).get();
+        Document doc = raplaConnection.get();
 
         // lessons information is inside span with CSS class .tooltip
         return doc.select(".tooltip");


### PR DESCRIPTION
Added an optional option to configure proxy settings by providing a proxy string in the format _host:port_ as parameter when calling the program.

This is useful if you are behind a company proxy and are otherwise unable to use the program.